### PR TITLE
Implement Filestorage.update and Filestorage.stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,81 +25,124 @@ create({ dir: './root' }, (err, storage) => { ... });
 ## Interface: filestorage
 
 ### Create new FileStorage
+
 `FileStorage(options)`
-  - `options: `[`<Object>`][]
-    - `dir: `[`<string>`][] -  data storage directory, it should be created
-          before FileStorage is used
-    - `minCompressSize: `[`<number>`][] -  minimal file size
-          to be compressed, default = 1024
+  - `options: `[`<Object>`]
+    - `dir: `[`<string>`] data storage directory, which should be created before
+          FileStorage is used
+    - `minCompressSize: `[`<number>`] minimal file size to be compressed,
+          default = 1024
 
 
 ### Write file to storage
-`FileStorage.prototype.write(id, data, opts, cb)`
-  - `id: `[`<Object>`][] -  common.Uint64, id of file
-  - `data: `[`<string>`][]` | `[`<Uint8Array>`][] - `<Buffer>` data to be written
-  - `opts: `[`<Object>`][]
-    - `checksum: `[`<string>`][] -  checksum type
-    - `dedupHash: `[`<string>`][] -  second checksum type
-  - `cb: `[`<Function>`][] -  callback
-    - `err: `[`<Error>`][]
-    - `checksum: `[`<string>`][] -  data checksum
-    - `dedupHash: `[`<string>`][] -  second data checksum
-    - `originalSize: `[`<number>`][] -  data size
 
-Throws: [`<TypeError>`][] if `opts.checksum` or `opts.dedupHash` is incorrect
+`FileStorage.prototype.write(id, data, opts, cb)`
+  - `id` `<common.Uint64>`id of file
+  - `data: `[`<string>`]` | `[`<Uint8Array>`] `<Buffer>`data to be written
+  - `opts: `[`<Object>`]
+    - `checksum: `[`<string>`] checksum type
+    - `dedupHash: `[`<string>`] second checksum type
+  - `cb: `[`<Function>`] callback
+    - `err: `[`<Error>`]
+    - `stats: `[`<Object>`]
+      - `checksum: `[`<string>`] data checksum
+      - `dedupHash: `[`<string>`] second data checksum
+      - `size: `[`<number>`] data size
+
+*Throws:* [`<TypeError>`] if `opts.checksum` or `opts.dedupHash` is incorrect
+
+
+### Update or write file in the storage
+
+`FileStorage.prototype.update(id, data, opts, cb)`
+  - `id` `<common.Uint64>`id of file
+  - `data: `[`<string>`]` | `[`<Uint8Array>`] `<Buffer>`data to be written
+  - `opts: `[`<Object>`]
+    - `checksum: `[`<string>`] checksum type
+    - `dedupHash: `[`<string>`] second checksum type
+  - `cb: `[`<Function>`] callback
+    - `err: `[`<Error>`]
+    - `stats: `[`<Object>`]
+      - `checksum: `[`<string>`] data checksum
+      - `dedupHash: `[`<string>`] second data checksum
+      - `size: `[`<number>`] data size
+      - `originalSize: `[`<number>`] size of original file
+
+*Throws:* [`<TypeError>`] if `opts.checksum` or `opts.dedupHash` is incorrect
+
+
+### Get information about file
+
+`FileStorage.prototype.stat(id, cb)`
+  - `id` `<common.Uint64>`id of file
+  - `cb: `[`<Function>`] callback
+    - `err: `[`<Error>`]
+    - `stats` `<fs.Stats>`
 
 
 ### Read file from storage
+
 `FileStorage.prototype.read(id, opts, cb)`
-  - `id: `[`<Object>`][] -  common.Uint64, id of file
-  - `opts: `[`<Object>`][]
-    - `encoding: `[`<string>`][]
-    - `compression: `[`<string>`][]
-  - `cb: `[`<Function>`][] -  callback
-    - `err: `[`<Error>`][]
-    - `data` - `<Buffer>`
+  - `id` `<common.Uint64>`id of file
+  - `opts: `[`<Object>`]
+    - `encoding: `[`<string>`]
+    - `compression: `[`<string>`]
+  - `cb: `[`<Function>`] callback
+    - `err: `[`<Error>`]
+    - `data: `[`<string>`] `<Buffer>`
 
 
 ### Delete file from storage
+
 `FileStorage.prototype.rm(id, cb)`
-  - `id: `[`<Object>`][] -  common.Uint64, id of file
-  - `cb: `[`<Function>`][] -  callback
-    - `err: `[`<Error>`][]
+  - `id` `<common.Uint64>`id of file
+  - `cb: `[`<Function>`] callback
+    - `err: `[`<Error>`]
 
 
 ### Compress file in storage
-`FileStorage.prototype.compress(id, compression, cb)`
-  - `id: `[`<Object>`][] -  common.Uint64, id of file
-  - `compression: `[`<string>`][] -  compression type
-  - `cb: `[`<Function>`][] -  callback
-    - `err: `[`<Error>`][]
-    - `compressed: `[`<boolean>`][] -  whether file was compressed
 
-Throws: [`<TypeError>`][] if compression is incorrect
+`FileStorage.prototype.compress(id, compression, cb)`
+  - `id` `<common.Uint64>`id of file
+  - `compression: `[`<string>`] compression type
+  - `cb: `[`<Function>`] callback
+    - `err: `[`<Error>`]
+    - `compressed: `[`<boolean>`] whether file was compressed
+
+*Throws:* [`<TypeError>`] if compression is incorrect
 
 
 ### Create new Filestorage and root directory if it doesn't exits
+
 `create(options, cb)`
-  - `options: `[`<Object>`][]
-    - `dir: `[`<string>`][] -  data storage directory
-    - `minCompressSize: `[`<number>`][] -  minimal file size to be compressed
-  - `cb: `[`<Function>`][] -  callback
-    - `err: `[`<Error>`][]
-    - `storage` - `<FileStorage>`
+  - `options: `[`<Object>`]
+    - `dir: `[`<string>`] data storage directory
+    - `minCompressSize: `[`<number>`] minimal file size to be compressed
+  - `cb: `[`<Function>`] callback
+    - `err: `[`<Error>`]
+    - `storage` `<FileStorage>`
 
 
 [`<Object>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
-[`<Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
 [`<Date>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
 [`<Function>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
+[`<RegExp>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+[`<DataView>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView
 [`<Map>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
 [`<WeakMap>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
 [`<Set>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 [`<WeakSet>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
+[`<Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+[`<ArrayBuffer>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
 [`<Int8Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array
 [`<Uint8Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
 [`<Uint8ClampedArray>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
+[`<Int16Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16Array
+[`<Uint16Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array
+[`<Int32Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array
+[`<Uint32Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array
 [`<Float32Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array
+[`<Float64Array>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array
 [`<Error>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 [`<EvalError>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError
 [`<TypeError>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError
@@ -113,3 +156,5 @@ Throws: [`<TypeError>`][] if compression is incorrect
 [`<string>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type
 [`<symbol>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Symbol_type
 [`<Primitive>`]: https://developer.mozilla.org/en-US/docs/Glossary/Primitive
+[`<Iterable>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
+[`<this>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this

--- a/lib/filestorage.js
+++ b/lib/filestorage.js
@@ -5,17 +5,17 @@ const path = require('path');
 const common = require('@metarhia/common');
 const utils = require('./utils');
 
-const CHECKSUM = 'CRC32';
-const DEDUP_HASH = 'SHA256';
 const MIN_COMPRESS_SIZE = 1024;
+
+const getFilepath = Symbol('getFilepath');
 
 class FileStorage {
 
   // Create new FileStorage
-  //   options <Object>
-  //     dir <string> data storage directory, it should be created
+  //   options - <Object>
+  //     dir - <string>, data storage directory, which should be created
   //         before FileStorage is used
-  //     minCompressSize <number> minimal file size
+  //     minCompressSize - <number>, minimal file size
   //         to be compressed, default = 1024
   constructor(options) {
     this.dir = path.resolve(options.dir);
@@ -23,78 +23,126 @@ class FileStorage {
   }
 
   // Write file to storage
-  //   id <Object> common.Uint64, id of file
-  //   data <string> | <Buffer> | <Uint8Array> data to be written
-  //   opts <Object>
-  //     checksum <string> checksum type
-  //     dedupHash <string> second checksum type
-  //   cb <Function> callback
-  //     err <Error>
-  //     checksum <string> data checksum
-  //     dedupHash <string> second data checksum
-  //     originalSize <number> data size
-  // Throws: <TypeError> if `opts.checksum` or `opts.dedupHash` is incorrect
+  //   id - <common.Uint64>, id of file
+  //   data - <string> | <Buffer> | <Uint8Array>, data to be written
+  //   opts - <Object>
+  //     checksum - <string>, checksum type
+  //     dedupHash - <string>, second checksum type
+  //   cb - <Function>, callback
+  //     err - <Error>
+  //     stats - <Object>
+  //       checksum - <string>, data checksum
+  //       dedupHash - <string>, second data checksum
+  //       size - <number>, data size
+  // Throws: <TypeError>, if `opts.checksum` or `opts.dedupHash` is incorrect
   write(id, data, opts, cb) {
-    const checksum = utils.computeHash(data, opts.checksum || CHECKSUM);
-    const dedupHash = utils.computeHash(data, opts.dedupHash || DEDUP_HASH);
-    const originalSize = Buffer.byteLength(data);
-
-    const file = utils.getFilepath(this.dir, common.idToPath(id));
+    const file = this[getFilepath](id);
     utils.mkdirp(path.dirname(file), err => {
       if (err) {
         cb(err);
         return;
       }
       fs.writeFile(file, data, err => {
-        if (err) cb(err);
-        else cb(null, checksum, dedupHash, originalSize);
+        if (err) {
+          cb(err);
+          return;
+        }
+        const stats = utils.getDataStats(data, opts.checksum, opts.dedupHash);
+        cb(null, stats);
       });
     });
   }
 
+  // Update file in the storage
+  //   id - <common.Uint64>, id of file
+  //   data - <string> | <Buffer> | <Uint8Array>, data to be written
+  //   opts - <Object>
+  //     checksum - <string>, checksum type
+  //     dedupHash - <string>, second checksum type
+  //   cb - <Function>, callback
+  //     err - <Error>
+  //     stats - <Object>
+  //       checksum - <string>, data checksum
+  //       dedupHash - <string>, second data checksum
+  //       size - <number>, data size
+  //       originalSize - <number>, size of original file
+  // Throws: <TypeError>, if `opts.checksum` or `opts.dedupHash` is incorrect
+  update(id, data, opts, cb) {
+    const file = this[getFilepath](id);
+    fs.stat(file, (err, fstats) => {
+      if (err) {
+        cb(err);
+        return;
+      }
+      fs.writeFile(file, data, err => {
+        if (err) {
+          cb(err);
+          return;
+        }
+        const stats = utils.getDataStats(data, opts.checksum, opts.dedupHash);
+        stats.originalSize = fstats.size;
+        cb(null, stats);
+      });
+    });
+  }
+
+  // Get information about file
+  //   id - <common.Uint64>, id of file
+  //   cb - <Function>, callback
+  //     err - <Error>
+  //     stats - <fs.Stats>
+  stat(id, cb) {
+    const file = this[getFilepath](id);
+    fs.stat(file, cb);
+  }
+
   // Read file from storage
-  //   id <Object> common.Uint64, id of file
-  //   opts <Object>
-  //     encoding <string>
-  //     compression <string>
-  //   cb <Function> callback
-  //     err <Error>
-  //     data <Buffer>
+  //   id - <common.Uint64>, id of file
+  //   opts - <Object>
+  //     encoding - <string>
+  //     compression - <string>
+  //   cb - <Function>, callback
+  //     err - <Error>
+  //     data - <Buffer> | <string>
   read(id, opts, cb) {
-    const file = utils.getFilepath(this.dir, common.idToPath(id));
+    const file = this[getFilepath](id);
     if (opts.compression) utils.uncompress(file, opts, cb);
     else fs.readFile(file, opts.encoding, cb);
   }
 
   // Delete file from storage
-  //   id <Object> common.Uint64, id of file
-  //   cb <Function> callback
-  //     err <Error>
+  //   id - <common.Uint64>, id of file
+  //   cb - <Function>, callback
+  //     err - <Error>
   rm(id, cb) {
-    const file = utils.getFilepath(this.dir, common.idToPath(id));
+    const file = this[getFilepath](id);
     fs.unlink(file, cb);
   }
 
   // Compress file in storage
-  //   id <Object> common.Uint64, id of file
-  //   compression <string> compression type
-  //   cb <Function> callback
-  //     err <Error>
-  //     compressed <boolean> whether file was compressed
-  // Throws: <TypeError> if compression is incorrect
+  //   id - <common.Uint64>, id of file
+  //   compression - <string>, compression type
+  //   cb - <Function>, callback
+  //     err - <Error>
+  //     compressed - <boolean>, whether file was compressed
+  // Throws: <TypeError>, if compression is incorrect
   compress(id, compression, cb) {
-    const file = utils.getFilepath(this.dir, common.idToPath(id));
+    const file = this[getFilepath](id);
     utils.compress(file, this.minCompressSize, compression, cb);
+  }
+
+  [getFilepath](id) {
+    return utils.getFilepath(this.dir, common.idToPath(id));
   }
 }
 
 // Create new Filestorage and root directory if it doesn't exits
-//   options <Object>
-//     dir <string> data storage directory
-//     minCompressSize <number> minimal file size to be compressed
-//   cb <Function> callback
-//     err <Error>
-//     storage <FileStorage>
+//   options - <Object>
+//     dir - <string>, data storage directory
+//     minCompressSize - <number>, minimal file size to be compressed
+//   cb - <Function>, callback
+//     err - <Error>
+//     storage - <FileStorage>
 const create = (options, cb) => {
   utils.mkdirp(path.resolve(options.dir), err => {
     if (err) cb(err);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,9 @@ const crypto = require('crypto');
 const { crc32 } = require('crc');
 const { zip, gzip } = require('compressing');
 
+const CHECKSUM = 'CRC32';
+const DEDUP_HASH = 'SHA256';
+
 const hashers = {
   CRC32: data => crc32(data).toString(16),
   SHA256: data => crypto.createHash('sha256').update(data).digest('hex'),
@@ -51,6 +54,12 @@ const computeHash = (data, checksum) => {
   }
   return hasher(data);
 };
+
+const getDataStats = (data, checksum, dedupHash) => ({
+  checksum: computeHash(data, checksum || CHECKSUM),
+  dedupHash: computeHash(data, dedupHash || DEDUP_HASH),
+  size: Buffer.byteLength(data),
+});
 
 const compress = (file, minCompressSize, compression, cb) => {
   fs.stat(file, (err, stats) => {
@@ -102,6 +111,7 @@ module.exports = {
   FS_EXT,
   getFilepath,
   computeHash,
+  getDataStats,
   mkdirp,
   rmdirp,
   compress,

--- a/test/filestorage.js
+++ b/test/filestorage.js
@@ -37,17 +37,17 @@ fsTest.test('Create root directory on create', test => {
 
 fsTest.test('Write string to file', (test, { storage }) => {
   const data = 'data0';
-  const checksum = '20cd1c30';
-  const dedupHash =
-    '4285d10832a8edf4cc7979e9a257e145dc5c934549f62e0bf1dc6070e67cc4ab';
+  const cs = '20cd1c30';
+  const dh = '4285d10832a8edf4cc7979e9a257e145dc5c934549f62e0bf1dc6070e67cc4ab';
+  const dataSize = 5;
 
   storage.write(new common.Uint64(0), data,
     { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, cs, dh, originalSize) => {
+    (err, { checksum, dedupHash, size }) => {
       test.error(err);
-      test.strictSame(cs, checksum);
-      test.strictSame(dh, dedupHash);
-      test.strictSame(originalSize, 5);
+      test.strictSame(checksum, cs);
+      test.strictSame(dedupHash, dh);
+      test.strictSame(size, dataSize);
 
       fs.readFile(utils.getFilepath(testDir, '0000', '0000'), (err, d) => {
         test.error(err);
@@ -59,17 +59,17 @@ fsTest.test('Write string to file', (test, { storage }) => {
 
 fsTest.test('Write Buffer to file', (test, { storage }) => {
   const data = 'data1';
-  const checksum = '57ca2ca6';
-  const dedupHash =
-    '5b41362bc82b7f3d56edc5a306db22105707d01ff4819e26faef9724a2d406c9';
+  const cs = '57ca2ca6';
+  const dh = '5b41362bc82b7f3d56edc5a306db22105707d01ff4819e26faef9724a2d406c9';
+  const dataSize = 5;
 
   storage.write(new common.Uint64(1), Buffer.from(data),
     { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, cs, dh, originalSize) => {
+    (err, { checksum, dedupHash, size }) => {
       test.error(err);
-      test.strictSame(cs, checksum);
-      test.strictSame(dh, dedupHash);
-      test.strictSame(originalSize, 5);
+      test.strictSame(checksum, cs);
+      test.strictSame(dedupHash, dh);
+      test.strictSame(size, dataSize);
 
       fs.readFile(utils.getFilepath(testDir, '0001', '0000'), (err, d) => {
         test.error(err);
@@ -217,16 +217,16 @@ fsTest.test('Compress big file using gzip', (test, { storage }) => {
 fsTest.test('Write and read small file', (test, { storage }) => {
   const id = new common.Uint64(8);
   const data = 'data8';
-  const checksum = '2e169402';
-  const dedupHash =
-    'b5cc74ab5bb5a5f1acc7407be3e4cbce8611c5ed07354ab9e510b74ee0b273cb';
+  const cs = '2e169402';
+  const dh = 'b5cc74ab5bb5a5f1acc7407be3e4cbce8611c5ed07354ab9e510b74ee0b273cb';
+  const dataSize = 5;
 
   storage.write(id, data, { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, cs, dh, originalSize) => {
+    (err, { checksum, dedupHash, size }) => {
       test.error(err);
-      test.strictSame(cs, checksum);
-      test.strictSame(dh, dedupHash);
-      test.strictSame(originalSize, 5);
+      test.strictSame(checksum, cs);
+      test.strictSame(dedupHash, dh);
+      test.strictSame(size, dataSize);
 
       storage.read(id, { encoding: 'utf8' }, (err, d) => {
         test.error(err);
@@ -239,16 +239,16 @@ fsTest.test('Write and read small file', (test, { storage }) => {
 fsTest.test('Write, compress and read small file', (test, { storage }) => {
   const id = new common.Uint64(9);
   const data = 'data9';
-  const checksum = '5911a494';
-  const dedupHash =
-    'bbe0aa41024faeac81813a0194a95637d54cc65c025e0efd857ce0afcd51573f';
+  const cs = '5911a494';
+  const dh = 'bbe0aa41024faeac81813a0194a95637d54cc65c025e0efd857ce0afcd51573f';
+  const dataSize = 5;
 
   storage.write(id, data, { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, cs, dh, originalSize) => {
+    (err, { checksum, dedupHash, size }) => {
       test.error(err);
-      test.strictSame(cs, checksum);
-      test.strictSame(dh, dedupHash);
-      test.strictSame(originalSize, 5);
+      test.strictSame(checksum, cs);
+      test.strictSame(dedupHash, dh);
+      test.strictSame(size, dataSize);
 
       storage.compress(id, 'ZIP', (err, compressed) => {
         test.error(err);
@@ -266,16 +266,16 @@ fsTest.test('Write, compress and read small file', (test, { storage }) => {
 fsTest.test('Write and read big file', (test, { storage }) => {
   const id = new common.Uint64(10);
   const data = 'data10'.repeat(1000);
-  const checksum = '828aaf45';
-  const dedupHash =
-    '7a8553c5934fd3b4a068a3d4c5bafc189e1fe8e0f7f46cbcc0fc1199249a39a2';
+  const cs = '828aaf45';
+  const dh = '7a8553c5934fd3b4a068a3d4c5bafc189e1fe8e0f7f46cbcc0fc1199249a39a2';
+  const dataSize = 6000;
 
   storage.write(id, data, { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, cs, dh, originalSize) => {
+    (err, { checksum, dedupHash, size }) => {
       test.error(err);
-      test.strictSame(cs, checksum);
-      test.strictSame(dh, dedupHash);
-      test.strictSame(originalSize, 6000);
+      test.strictSame(checksum, cs);
+      test.strictSame(dedupHash, dh);
+      test.strictSame(size, dataSize);
 
       storage.read(id, { encoding: 'utf8' }, (err, d) => {
         test.error(err);
@@ -288,16 +288,16 @@ fsTest.test('Write and read big file', (test, { storage }) => {
 fsTest.test('Write, compress and read big file', (test, { storage }) => {
   const id = new common.Uint64(11);
   const data = 'data11'.repeat(1000);
-  const checksum = '5928f9a';
-  const dedupHash =
-    'f1cf91dea01f77fd860645de51462794cfbbae0a14d81350b21934e58a69941d';
+  const cs = '5928f9a';
+  const dh = 'f1cf91dea01f77fd860645de51462794cfbbae0a14d81350b21934e58a69941d';
+  const dataSize = 6000;
 
   storage.write(id, data, { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, cs, dh, originalSize) => {
+    (err, { checksum, dedupHash, size }) => {
       test.error(err);
-      test.strictSame(cs, checksum);
-      test.strictSame(dh, dedupHash);
-      test.strictSame(originalSize, 6000);
+      test.strictSame(checksum, cs);
+      test.strictSame(dedupHash, dh);
+      test.strictSame(size, dataSize);
 
       storage.compress(id, 'ZIP', (err, compressed) => {
         test.error(err);
@@ -315,16 +315,16 @@ fsTest.test('Write, compress and read big file', (test, { storage }) => {
 fsTest.test('Write and read small file', (test, { storage }) => {
   const id = new common.Uint64(12);
   const data = '白い猫でも黒い猫でも鼠を取る猫はいい猫だ';
-  const checksum = '289722d';
-  const dedupHash =
-    'fab270bfcdc81e464611cd112e95c6b9590ba55483fbfe2dda98d67ddc741ab3';
+  const cs = '289722d';
+  const dh = 'fab270bfcdc81e464611cd112e95c6b9590ba55483fbfe2dda98d67ddc741ab3';
+  const dataSize = 60;
 
   storage.write(id, data, { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, cs, dh, originalSize) => {
+    (err, { checksum, dedupHash, size }) => {
       test.error(err);
-      test.strictSame(cs, checksum);
-      test.strictSame(dh, dedupHash);
-      test.strictSame(originalSize, 60);
+      test.strictSame(checksum, cs);
+      test.strictSame(dedupHash, dh);
+      test.strictSame(size, dataSize);
 
       storage.read(id, { encoding: 'utf8' }, (err, d) => {
         test.error(err);
@@ -332,4 +332,69 @@ fsTest.test('Write and read small file', (test, { storage }) => {
         test.end();
       });
     });
+});
+
+fsTest.test('Get file stats', (test, { storage }) => {
+  const data = 'data13';
+  const file = utils.getFilepath(testDir, '000d', '0000');
+
+  fs.mkdir(path.join(testDir, '000d'), err => {
+    test.error(err);
+
+    fs.writeFile(file, data, err => {
+      test.error(err);
+
+      fs.stat(file, (err, fstats) => {
+        test.error(err);
+
+        storage.stat(new common.Uint64(13), (err, stats) => {
+          test.error(err);
+          test.strictSame(stats, fstats);
+          test.end();
+        });
+      });
+    });
+  });
+});
+
+fsTest.test('Update file', (test, { storage }) => {
+  const data1 = 'data15';
+  const cs1 = 'bb53e75f';
+  const dh1 =
+    '87fef323635f22fc88999957a585c3cf3f8383029c8501e52928a14028c0af2c';
+  const dataSize1 = 6;
+
+  const data2 = 'another data';
+  const cs2 = '963fe1ef';
+  const dh2 =
+    'f3cfa0c4064755101ffbcdc8a8d1b9dccc46d45b3a82f800a6eaab42e65f14c9';
+  const dataSize2 = 12;
+
+  const id = new common.Uint64(15);
+
+  storage.write(id, data1,
+    { checksum: 'CRC32', dedupHash: 'SHA256' },
+    (err, { checksum, dedupHash, size }) => {
+      test.error(err);
+      test.strictSame(checksum, cs1);
+      test.strictSame(dedupHash, dh1);
+      test.strictSame(size, dataSize1);
+
+      storage.update(id, data2,
+        { checksum: 'CRC32', dedupHash: 'SHA256' },
+        (err, { checksum, dedupHash, size, originalSize }) => {
+          test.error(err);
+          test.strictSame(checksum, cs2);
+          test.strictSame(dedupHash, dh2);
+          test.strictSame(size, dataSize2);
+          test.strictSame(originalSize, dataSize1);
+
+          fs.readFile(utils.getFilepath(testDir, '000f', '0000'), (err, d) => {
+            test.error(err);
+            test.strictSame(d.toString(), data2);
+            test.end();
+          });
+        });
+    });
+
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -60,6 +60,18 @@ metatests.case('', utils, {
   ],
 });
 
+metatests.testSync('getDataStats', test => {
+  const data = 'data6';
+  const cs = '9c67b4b76a18503009f542ef7c93dc7ac94aebbc6141515bea4e63e3068373a6';
+  const dh = 'c9aeb905';
+  const dataSize = 5;
+
+  const stats = utils.getDataStats(data, 'SHA256', 'CRC32');
+  test.strictSame(stats.checksum, cs);
+  test.strictSame(stats.dedupHash, dh);
+  test.strictSame(stats.size, dataSize);
+});
+
 metatests.test('', test => {
   const dir = path.join(testDir, 'some', 'path', 'to', 'nested', 'dir');
   utils.mkdirp(dir, err => {


### PR DESCRIPTION
- `Filestorage.update`, `Filestorage.stat` are needed for `fs.provider` in [globalstorage](https://github.com/metarhia/globalstorage/blob/master/lib/fs.provider.js).
- Returning file stats as an object in `Filestorage.write` and `Filestorage.update` will decrease the number of arguments.