### PR TITLE
Replace callbacks with promises

### DIFF
--- a/lib/filestorage.js
+++ b/lib/filestorage.js
@@ -27,10 +27,7 @@ class FileStorage {
   //   opts - <Object>
   //     checksum - <string>, checksum type
   //     dedupHash - <string>, second checksum type
-  // Returns: <Object>, stats
-  //   checksum - <string>, data checksum
-  //   dedupHash - <string>, second data checksum
-  //   size - <number>, data size
+  // Returns: <Promise>
   // Throws: <TypeError>, if `opts.checksum` or `opts.dedupHash` is incorrect
   async write(id, data, opts) {
     const file = this[getFilepath](id);
@@ -46,11 +43,7 @@ class FileStorage {
   //   opts - <Object>
   //     checksum - <string>, checksum type
   //     dedupHash - <string>, second checksum type
-  // Returns: <Object>, stats
-  //   checksum - <string>, data checksum
-  //   dedupHash - <string>, second data checksum
-  //   size - <number>, data size
-  //   originalSize - <number>, size of original file
+  // Returns: <Promise>
   // Throws: <TypeError>, if `opts.checksum` or `opts.dedupHash` is incorrect
   async update(id, data, opts) {
     const file = this[getFilepath](id);
@@ -64,7 +57,7 @@ class FileStorage {
 
   // Get information about file
   //   id - <common.Uint64> | <number> | <BigInt>, id of file
-  // Returns: <fs.Stats>
+  // Returns: <Promise>
   async stat(id) {
     const file = this[getFilepath](id);
     return fs.stat(file);
@@ -75,7 +68,7 @@ class FileStorage {
   //   opts - <Object>
   //     encoding - <string>
   //     compression - <string>
-  // Returns: <Buffer> | <string>, data
+  // Returns: <Promise>
   async read(id, opts) {
     const file = this[getFilepath](id);
     if (opts.compression) return utils.uncompress(file, opts);
@@ -92,7 +85,7 @@ class FileStorage {
   // Compress file in storage
   //   id - <common.Uint64> | <number> | <BigInt>, id of file
   //   compression - <string>, compression type
-  // Returns: <boolean>, whether file was compressed
+  // Returns: <Promise>
   // Throws: <TypeError>, if compression is incorrect
   async compress(id, compression) {
     const file = this[getFilepath](id);
@@ -108,7 +101,7 @@ class FileStorage {
 //   options - <Object>
 //     path - <string>, data storage directory
 //     minCompressSize - <number>, minimal file size to be compressed
-// Returns: <FileStorage>, instance
+// Returns: <Promise>
 const create = async options => {
   await utils.mkdirpPromise(path.resolve(options.path));
   return new FileStorage(options);

--- a/lib/filestorage.js
+++ b/lib/filestorage.js
@@ -34,7 +34,7 @@ class FileStorage {
   // Throws: <TypeError>, if `opts.checksum` or `opts.dedupHash` is incorrect
   async write(id, data, opts) {
     const file = this[getFilepath](id);
-    await utils.mkdirRecursive(path.dirname(file));
+    await utils.mkdirpPromise(path.dirname(file));
     await fs.writeFile(file, data);
 
     return utils.getDataStats(data, opts.checksum, opts.dedupHash);
@@ -106,11 +106,11 @@ class FileStorage {
 
 // Create new Filestorage and root directory if it doesn't exits
 //   options - <Object>
-//     dir - <string>, data storage directory
+//     path - <string>, data storage directory
 //     minCompressSize - <number>, minimal file size to be compressed
 // Returns: <FileStorage>, instance
 const create = async options => {
-  await utils.mkdirRecursive(path.resolve(options.path));
+  await utils.mkdirpPromise(path.resolve(options.path));
   return new FileStorage(options);
 };
 

--- a/lib/filestorage.js
+++ b/lib/filestorage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('./fs');
 const path = require('path');
 const common = require('@metarhia/common');
 const utils = require('./utils');
@@ -12,126 +12,95 @@ const getFilepath = Symbol('getFilepath');
 class FileStorage {
   // Create new FileStorage
   //   options - <Object>
-  //     dir - <string>, data storage directory, which should be created
+  //     path - <string>, data storage directory, which should be created
   //         before FileStorage is used
   //     minCompressSize - <number>, minimal file size
   //         to be compressed, default = 1024
   constructor(options) {
-    this.dir = path.resolve(options.dir);
+    this.path = path.resolve(options.path);
     this.minCompressSize = options.minCompressSize || MIN_COMPRESS_SIZE;
   }
 
   // Write file to storage
-  //   id - <common.Uint64>, id of file
+  //   id - <common.Uint64> | <number> | <BigInt>, id of file
   //   data - <string> | <Buffer> | <Uint8Array>, data to be written
   //   opts - <Object>
   //     checksum - <string>, checksum type
   //     dedupHash - <string>, second checksum type
-  //   cb - <Function>, callback
-  //     err - <Error>
-  //     stats - <Object>
-  //       checksum - <string>, data checksum
-  //       dedupHash - <string>, second data checksum
-  //       size - <number>, data size
+  // Returns: <Object>, stats
+  //   checksum - <string>, data checksum
+  //   dedupHash - <string>, second data checksum
+  //   size - <number>, data size
   // Throws: <TypeError>, if `opts.checksum` or `opts.dedupHash` is incorrect
-  write(id, data, opts, cb) {
+  async write(id, data, opts) {
     const file = this[getFilepath](id);
-    common.mkdirp(path.dirname(file), err => {
-      if (err) {
-        cb(err);
-        return;
-      }
-      fs.writeFile(file, data, err => {
-        if (err) {
-          cb(err);
-          return;
-        }
-        const stats = utils.getDataStats(data, opts.checksum, opts.dedupHash);
-        cb(null, stats);
-      });
-    });
+    await utils.mkdirRecursive(path.dirname(file));
+    await fs.writeFile(file, data);
+
+    return utils.getDataStats(data, opts.checksum, opts.dedupHash);
   }
 
   // Update file in the storage
-  //   id - <common.Uint64>, id of file
+  //   id - <common.Uint64> | <number> | <BigInt>, id of file
   //   data - <string> | <Buffer> | <Uint8Array>, data to be written
   //   opts - <Object>
   //     checksum - <string>, checksum type
   //     dedupHash - <string>, second checksum type
-  //   cb - <Function>, callback
-  //     err - <Error>
-  //     stats - <Object>
-  //       checksum - <string>, data checksum
-  //       dedupHash - <string>, second data checksum
-  //       size - <number>, data size
-  //       originalSize - <number>, size of original file
+  // Returns: <Object>, stats
+  //   checksum - <string>, data checksum
+  //   dedupHash - <string>, second data checksum
+  //   size - <number>, data size
+  //   originalSize - <number>, size of original file
   // Throws: <TypeError>, if `opts.checksum` or `opts.dedupHash` is incorrect
-  update(id, data, opts, cb) {
+  async update(id, data, opts) {
     const file = this[getFilepath](id);
-    fs.stat(file, (err, fstats) => {
-      if (err) {
-        cb(err);
-        return;
-      }
-      fs.writeFile(file, data, err => {
-        if (err) {
-          cb(err);
-          return;
-        }
-        const stats = utils.getDataStats(data, opts.checksum, opts.dedupHash);
-        stats.originalSize = fstats.size;
-        cb(null, stats);
-      });
-    });
+    const fstats = await fs.stat(file);
+    await fs.writeFile(file, data);
+
+    const stats = utils.getDataStats(data, opts.checksum, opts.dedupHash);
+    stats.originalSize = fstats.size;
+    return stats;
   }
 
   // Get information about file
-  //   id - <common.Uint64>, id of file
-  //   cb - <Function>, callback
-  //     err - <Error>
-  //     stats - <fs.Stats>
-  stat(id, cb) {
+  //   id - <common.Uint64> | <number> | <BigInt>, id of file
+  // Returns: <fs.Stats>
+  async stat(id) {
     const file = this[getFilepath](id);
-    fs.stat(file, cb);
+    return fs.stat(file);
   }
 
   // Read file from storage
-  //   id - <common.Uint64>, id of file
+  //   id - <common.Uint64> | <number> | <BigInt>, id of file
   //   opts - <Object>
   //     encoding - <string>
   //     compression - <string>
-  //   cb - <Function>, callback
-  //     err - <Error>
-  //     data - <Buffer> | <string>
-  read(id, opts, cb) {
+  // Returns: <Buffer> | <string>, data
+  async read(id, opts) {
     const file = this[getFilepath](id);
-    if (opts.compression) utils.uncompress(file, opts, cb);
-    else fs.readFile(file, opts.encoding, cb);
+    if (opts.compression) return utils.uncompress(file, opts);
+    return fs.readFile(file, opts.encoding);
   }
 
   // Delete file from storage
-  //   id - <common.Uint64>, id of file
-  //   cb - <Function>, callback
-  //     err - <Error>
-  rm(id, cb) {
+  //   id - <common.Uint64> | <number> | <BigInt>, id of file
+  async rm(id) {
     const file = this[getFilepath](id);
-    fs.unlink(file, cb);
+    await fs.unlink(file);
   }
 
   // Compress file in storage
-  //   id - <common.Uint64>, id of file
+  //   id - <common.Uint64> | <number> | <BigInt>, id of file
   //   compression - <string>, compression type
-  //   cb - <Function>, callback
-  //     err - <Error>
-  //     compressed - <boolean>, whether file was compressed
+  // Returns: <boolean>, whether file was compressed
   // Throws: <TypeError>, if compression is incorrect
-  compress(id, compression, cb) {
+  async compress(id, compression) {
     const file = this[getFilepath](id);
-    utils.compress(file, this.minCompressSize, compression, cb);
+    return utils.compress(file, this.minCompressSize, compression);
   }
 
   [getFilepath](id) {
-    return utils.getFilepath(this.dir, common.idToPath(id));
+    return utils.getFilepath(this.path, common.idToPath(id));
   }
 }
 
@@ -139,14 +108,10 @@ class FileStorage {
 //   options - <Object>
 //     dir - <string>, data storage directory
 //     minCompressSize - <number>, minimal file size to be compressed
-//   cb - <Function>, callback
-//     err - <Error>
-//     storage - <FileStorage>
-const create = (options, cb) => {
-  common.mkdirp(path.resolve(options.dir), err => {
-    if (err) cb(err);
-    else cb(null, new FileStorage(options));
-  });
+// Returns: <FileStorage>, instance
+const create = async options => {
+  await utils.mkdirRecursive(path.resolve(options.path));
+  return new FileStorage(options);
 };
 
 module.exports = { FileStorage, create };

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// TODO: this file should be removed and `fs.promises` used instead
+// when support for Node.js 8 is dropped
+
+const fs = require('fs');
+const { promisify } = require('util');
+
+const { iter } = require('@metarhia/common');
+
+const list = [
+  'readFile',
+  'writeFile',
+  'unlink',
+  'rename',
+  'stat',
+  'access',
+  'mkdir',
+  'rmdir',
+  'readdir',
+];
+
+if (process.version.slice(1).split('.')[0] >= 10) {
+  module.exports = fs.promises;
+} else {
+  module.exports = iter(list).collectWith(
+    {},
+    (obj, name) => (obj[name] = promisify(fs[name]))
+  );
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -20,7 +20,7 @@ const list = [
   'readdir',
 ];
 
-if (process.version.slice(1).split('.')[0] >= 10) {
+if (fs.promises) {
   module.exports = fs.promises;
 } else {
   module.exports = iter(list).collectWith(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,12 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('./fs');
 const path = require('path');
 const crypto = require('crypto');
 const { crc32 } = require('crc');
+const util = require('util');
+const common = require('@metarhia/common');
 const { zip, gzip } = require('compressing');
-const metasync = require('metasync');
 
 const CHECKSUM = 'CRC32';
 const DEDUP_HASH = 'SHA256';
@@ -28,32 +29,6 @@ const FS_EXT = 'f';
 
 const getFilepath = (...parts) => `${path.join(...parts)}.${FS_EXT}`;
 
-const rmdirp = (dir, cb) => {
-  fs.stat(dir, (err, stats) => {
-    if (err) {
-      if (err.code === 'ENOENT') cb(null);
-      else cb(err);
-      return;
-    }
-
-    if (stats.isDirectory()) {
-      fs.readdir(dir, (err, files) => {
-        if (err) {
-          cb(err);
-          return;
-        }
-        files = files.map(file => path.join(dir, file));
-        metasync.each(files, rmdirp, err => {
-          if (err) cb(err);
-          else fs.rmdir(dir, cb);
-        });
-      });
-    } else {
-      fs.unlink(dir, cb);
-    }
-  });
-};
-
 const computeHash = (data, checksum) => {
   const hasher = hashers[checksum];
   if (!hasher) {
@@ -68,45 +43,57 @@ const getDataStats = (data, checksum, dedupHash) => ({
   size: Buffer.byteLength(data),
 });
 
-const compress = (file, minCompressSize, compression, cb) => {
-  fs.stat(file, (err, stats) => {
-    if (err || stats.size <= minCompressSize) {
-      cb(err, false);
-      return;
-    }
-    const filec = file + 'z';
-    const compressor = compressors[compression];
-    if (!compressor) {
-      throw new Error(`Unknown compression type ${compression} specified`);
-    }
-    compressor
-      .compressFile(file, filec)
-      .then(() =>
-        fs.rename(filec, file, err => {
-          if (err) cb(err, false);
-          else cb(null, true);
-        })
-      )
-      .catch(err => cb(err, false));
-  });
+const mkdirRecursive = util.promisify(common.mkdirp);
+
+const rmRecursive = async dir => {
+  try {
+    await fs.access(dir);
+  } catch (err) {
+    if (err.code === 'ENOENT') return;
+    throw new Error(`Cannot access directory '${dir}': ${err.message}`);
+  }
+
+  const files = await fs.readdir(dir);
+
+  for (let file of files) {
+    file = path.join(dir, file);
+    const stats = await fs.stat(file);
+
+    if (stats.isDirectory()) await rmRecursive(file);
+    else await fs.unlink(file);
+  }
+
+  await fs.rmdir(dir);
 };
 
-const uncompress = (file, opts, cb) => {
-  fs.access(file, err => {
-    if (err) {
-      cb(err);
-      return;
-    }
-    const compressor = compressors[opts.compression];
-    if (!compressor) {
-      throw new Error(`Unknown compression type ${opts.compression} specified`);
-    }
+const compress = async (file, minCompressSize, compression) => {
+  const compressor = compressors[compression];
+  if (!compressor) {
+    throw new Error(`Unknown compression type ${compression} specified`);
+  }
+
+  const stats = await fs.stat(file);
+  if (stats.size <= minCompressSize) return false;
+
+  const filec = file + 'z';
+  await compressor.compressFile(file, filec);
+  await fs.rename(filec, file);
+  return true;
+};
+
+const uncompress = async (file, opts) => {
+  const compressor = compressors[opts.compression];
+  if (!compressor) {
+    throw new Error(`Unknown compression type ${opts.compression} specified`);
+  }
+
+  return new Promise((res, rej) => {
     const buffers = [];
     new compressor.UncompressStream({ source: file })
-      .on('error', cb)
+      .on('error', rej)
       .on('finish', () => {
-        if (opts.encoding) cb(null, buffers.join());
-        else cb(null, Buffer.concat(buffers));
+        if (opts.encoding) res(buffers.join(''));
+        else res(Buffer.concat(buffers));
       })
       .on('entry', (header, stream, next) => {
         if (opts.encoding) stream.setEncoding(opts.encoding);
@@ -120,7 +107,8 @@ module.exports = {
   getFilepath,
   computeHash,
   getDataStats,
-  rmdirp,
+  mkdirRecursive,
+  rmRecursive,
   compress,
   uncompress,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,13 +64,19 @@ const uncompress = async (file, opts) => {
     throw new Error(`Unknown compression type ${opts.compression} specified`);
   }
 
-  return new Promise((res, rej) => {
+  if (opts.compression === 'GZIP') {
+    const memoryStream = new common.MemoryWritable();
+    compressor.uncompress(file, memoryStream);
+    return memoryStream.getData(opts.encoding);
+  }
+
+  return new Promise((resolve, reject) => {
     const buffers = [];
     new compressor.UncompressStream({ source: file })
-      .once('error', rej)
+      .once('error', reject)
       .once('finish', () => {
-        if (opts.encoding) res(buffers.join(''));
-        else res(Buffer.concat(buffers));
+        if (opts.encoding) resolve(buffers.join(''));
+        else resolve(Buffer.concat(buffers));
       })
       .on('entry', (header, stream, next) => {
         if (opts.encoding) stream.setEncoding(opts.encoding);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,8 +67,8 @@ const uncompress = async (file, opts) => {
   return new Promise((res, rej) => {
     const buffers = [];
     new compressor.UncompressStream({ source: file })
-      .on('error', rej)
-      .on('finish', () => {
+      .once('error', rej)
+      .once('finish', () => {
         if (opts.encoding) res(buffers.join(''));
         else res(Buffer.concat(buffers));
       })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,29 +43,6 @@ const getDataStats = (data, checksum, dedupHash) => ({
   size: Buffer.byteLength(data),
 });
 
-const mkdirRecursive = util.promisify(common.mkdirp);
-
-const rmRecursive = async dir => {
-  try {
-    await fs.access(dir);
-  } catch (err) {
-    if (err.code === 'ENOENT') return;
-    throw new Error(`Cannot access directory '${dir}': ${err.message}`);
-  }
-
-  const files = await fs.readdir(dir);
-
-  for (let file of files) {
-    file = path.join(dir, file);
-    const stats = await fs.stat(file);
-
-    if (stats.isDirectory()) await rmRecursive(file);
-    else await fs.unlink(file);
-  }
-
-  await fs.rmdir(dir);
-};
-
 const compress = async (file, minCompressSize, compression) => {
   const compressor = compressors[compression];
   if (!compressor) {
@@ -107,8 +84,7 @@ module.exports = {
   getFilepath,
   computeHash,
   getDataStats,
-  mkdirRecursive,
-  rmRecursive,
   compress,
   uncompress,
+  mkdirpPromise: util.promisify(common.mkdirp),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@metarhia/common": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@metarhia/common/-/common-2.0.0.tgz",
-      "integrity": "sha512-14cQm2PVHsUew6XJ6rpyhl7mQG1Gp7GPvLOV1FsjUf1vXYFdMYLzriywGHwwwSIhOekQhpIqj6NfQml3wJ260A=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@metarhia/common/-/common-2.1.0.tgz",
+      "integrity": "sha512-HmIb98pFBlnKN44z1HVugBmsHrLJWA2tBsP3iLh/ehg0PVkNUHOQhDV2tI2NvbCJeTlmPrZ8rdw0BcfPW1q47Q=="
     },
     "acorn": {
       "version": "6.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
-      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -216,21 +216,43 @@
       "dev": true
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -456,9 +478,9 @@
       "dev": true
     },
     "eslint-config-prettier": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.2.0.tgz",
-      "integrity": "sha512-y0uWc/FRfrHhpPZCYflWC8aE0KRJRY04rdZVfl8cL3sEZmOYyaBdhdlQPjKZBnuRMyLVK+JUZr7HaZFClQiH4w==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz",
+      "integrity": "sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -519,9 +541,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz",
-      "integrity": "sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.3.tgz",
+      "integrity": "sha512-qeVf/UwXFJbeyLbxuY8RgqDyEKCkqV7YC+E5S5uOjAp4tOc8zj01JP3ucoBM8JcEqd1qRasJSg6LLlisirfy0Q==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -534,7 +556,7 @@
         "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.10.0"
+        "resolve": "^1.11.0"
       },
       "dependencies": {
         "debug": {
@@ -565,9 +587,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
-      "integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
+      "integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -1138,14 +1160,14 @@
       }
     },
     "metatests": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/metatests/-/metatests-0.6.5.tgz",
-      "integrity": "sha512-+MEsUN9AOgYq61TMLcZrKOAPZflTbQcLuHZT55xFnBnpB2Y44yWLpJ+1YIznJh+Mz8Wqxv4VotHC7ONkORqQeg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/metatests/-/metatests-0.7.0.tgz",
+      "integrity": "sha512-TaxwlReeo2XXLEKEFtfN9GUOcXAlimqo3t251JSRxdpQGBexiwFS5lCx6G2s3isnZy4p0W4nZ6UdKLb+mTiYEA==",
       "dev": true,
       "requires": {
         "@metarhia/common": "^1.4.2",
         "tap-mocha-reporter": "^4.0.1",
-        "yaml": "^1.5.0",
+        "tap-yaml": "^1.0.0",
         "yargs": "^13.2.2"
       },
       "dependencies": {
@@ -1239,12 +1261,6 @@
       "requires": {
         "path-key": "^2.0.0"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -1426,9 +1442,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
-      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -1526,9 +1542,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -1957,48 +1973,40 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -2035,21 +2043,21 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.5.1.tgz",
-      "integrity": "sha512-btfJvMOgVthGZSgHBMrDkLuQu4YxOycw6kwuC67cUEOKJmmNozjIa02eKvuSq7usqqqpwwCvflGTF6JcDvSudw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
+      "integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.4.5"
       }
     },
     "yargs": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+      "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
+        "cliui": "^5.0.0",
         "find-up": "^3.0.0",
         "get-caller-file": "^2.0.1",
         "os-locale": "^3.1.0",
@@ -2059,7 +2067,7 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.0.0"
+        "yargs-parser": "^13.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2134,9 +2142,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
-      "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "@metarhia/common": "^2.0.0",
+    "@metarhia/common": "^2.1.0",
     "compressing": "^1.4.0",
     "crc": "^3.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
   "devDependencies": {
     "eslint": "^5.16.0",
     "eslint-config-metarhia": "^7.0.0",
-    "eslint-config-prettier": "^4.1.0",
-    "eslint-plugin-import": "^2.17.2",
-    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-config-prettier": "^4.3.0",
+    "eslint-plugin-import": "^2.17.3",
+    "eslint-plugin-prettier": "^3.1.0",
     "metasync": "^0.3.31",
-    "metatests": "^0.6.5",
-    "prettier": "^1.17.0"
+    "metatests": "^0.7.0",
+    "prettier": "^1.18.2"
   }
 }

--- a/test/filestorage.js
+++ b/test/filestorage.js
@@ -1,9 +1,11 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('../lib/fs');
 const path = require('path');
+
 const { create } = require('..');
 const utils = require('../lib/utils');
+
 const metatests = require('metatests');
 const common = require('@metarhia/common');
 
@@ -13,423 +15,244 @@ const minCompressSize = 1000;
 const fsTest = metatests.test('Filestorage');
 fsTest.endAfterSubtests();
 
-fsTest.beforeEach((test, cb) => {
-  create({ dir: testDir, minCompressSize }, (err, storage) => {
-    test.error(err);
-    cb({ storage });
-  });
+let idCounter = 0;
+
+fsTest.beforeEach(async () => {
+  const storage = await create({ path: testDir, minCompressSize });
+  const id = new common.Uint64(idCounter++);
+  return { storage, id };
 });
 
-fsTest.afterEach((test, cb) => {
-  utils.rmdirp(testDir, err => {
-    test.error(err);
-    cb();
-  });
-});
+fsTest.afterEach(() => utils.rmRecursive(testDir));
 
-fsTest.test('Create root directory on create', test => {
-  const dir = testDir + 'create';
-  create({ dir }, err => {
-    test.error(err);
-    test.strictSame(fs.existsSync(dir), true);
-    utils.rmdirp(dir, err => {
-      test.error(err);
-      test.end();
-    });
-  });
-});
+fsTest.test('Create root directory on create', () => fs.access(testDir));
 
-fsTest.test('Write string to file', (test, { storage }) => {
+fsTest.test('Write string to file', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
+  const opts = { checksum: 'CRC32', dedupHash: 'SHA256' };
   const data = 'data0';
-  const cs = '20cd1c30';
-  const dh = '4285d10832a8edf4cc7979e9a257e145dc5c934549f62e0bf1dc6070e67cc4ab';
-  const dataSize = 5;
+  const dataStats = {
+    checksum: '20cd1c30',
+    dedupHash:
+      '4285d10832a8edf4cc7979e9a257e145dc5c934549f62e0bf1dc6070e67cc4ab',
+    size: 5,
+  };
 
-  storage.write(
-    new common.Uint64(0),
-    data,
-    { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, { checksum, dedupHash, size }) => {
-      test.error(err);
-      test.strictSame(checksum, cs);
-      test.strictSame(dedupHash, dh);
-      test.strictSame(size, dataSize);
-
-      fs.readFile(utils.getFilepath(testDir, '0000', '0000'), (err, d) => {
-        test.error(err);
-        test.strictSame(d.toString(), data);
-        test.end();
-      });
-    }
-  );
+  await test.resolves(storage.write(id, data, opts), dataStats);
+  await test.resolves(fs.readFile(file, 'utf8'), data);
 });
 
-fsTest.test('Write Buffer to file', (test, { storage }) => {
-  const data = 'data1';
-  const cs = '57ca2ca6';
-  const dh = '5b41362bc82b7f3d56edc5a306db22105707d01ff4819e26faef9724a2d406c9';
-  const dataSize = 5;
+fsTest.test('Write Buffer to file', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
+  const opts = { checksum: 'CRC32', dedupHash: 'SHA256' };
+  const data = Buffer.from('data1');
+  const dataStats = {
+    checksum: '57ca2ca6',
+    dedupHash:
+      '5b41362bc82b7f3d56edc5a306db22105707d01ff4819e26faef9724a2d406c9',
+    size: 5,
+  };
 
-  storage.write(
-    new common.Uint64(1),
-    Buffer.from(data),
-    { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, { checksum, dedupHash, size }) => {
-      test.error(err);
-      test.strictSame(checksum, cs);
-      test.strictSame(dedupHash, dh);
-      test.strictSame(size, dataSize);
-
-      fs.readFile(utils.getFilepath(testDir, '0001', '0000'), (err, d) => {
-        test.error(err);
-        test.strictSame(d.toString(), data);
-        test.end();
-      });
-    }
-  );
+  await test.resolves(storage.write(id, data, opts), dataStats);
+  await test.resolves(fs.readFile(file), data);
 });
 
-fsTest.test('Read file', (test, { storage }) => {
+fsTest.test('Read file', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
   const data = 'data2';
 
-  fs.mkdir(path.join(testDir, '0002'), err => {
-    test.error(err);
-
-    fs.writeFile(utils.getFilepath(testDir, '0002', '0000'), data, err => {
-      test.error(err);
-
-      storage.read(new common.Uint64(2), {}, (err, d) => {
-        test.error(err);
-        test.strictSame(d.toString(), data);
-        test.end();
-      });
-    });
-  });
+  await fs.mkdir(path.join(testDir, pathPart));
+  await fs.writeFile(file, data);
+  await test.resolves(storage.read(id, { encoding: 'utf8' }), data);
 });
 
-fsTest.test('Remove file', (test, { storage }) => {
+fsTest.test('Remove file', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
   const data = 'data3';
-  const file = utils.getFilepath(testDir, '0003', '0000');
 
-  fs.mkdir(path.join(testDir, '0003'), err => {
-    test.error(err);
+  await fs.mkdir(path.join(testDir, pathPart));
+  await fs.writeFile(file, data);
+  await storage.rm(id);
 
-    fs.writeFile(file, data, err => {
-      test.error(err);
-
-      storage.rm(new common.Uint64(3), err => {
-        test.error(err);
-        test.strictSame(fs.existsSync(file), false);
-        test.end();
-      });
-    });
-  });
+  const err = await test.rejects(fs.access(file));
+  test.strictSame(err.code, 'ENOENT');
 });
 
-fsTest.test('Compress small file using zip', (test, { storage }) => {
+fsTest.test('Compress small file using zip', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
   const data = 'data4';
-  const file = utils.getFilepath(testDir, '0004', '0000');
 
-  fs.mkdir(path.join(testDir, '0004'), err => {
-    test.error(err);
-
-    fs.writeFile(utils.getFilepath(testDir, '0004', '0000'), data, err => {
-      test.error(err);
-
-      storage.compress(new common.Uint64(4), 'ZIP', (err, compressed) => {
-        test.error(err);
-        test.strictSame(compressed, false);
-
-        fs.readFile(file, 'utf8', (err, d) => {
-          test.error(err);
-          test.strictSame(d, data);
-          test.end();
-        });
-      });
-    });
-  });
+  await fs.mkdir(path.join(testDir, pathPart));
+  await fs.writeFile(file, data);
+  await test.resolves(storage.compress(id, 'ZIP'), false);
+  await test.resolves(fs.readFile(file, 'utf8'), data);
 });
 
-fsTest.test('Compress small file using gzip', (test, { storage }) => {
+fsTest.test('Compress small file using gzip', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
   const data = 'data5';
-  const file = utils.getFilepath(testDir, '0005', '0000');
 
-  fs.mkdir(path.join(testDir, '0005'), err => {
-    test.error(err);
-
-    fs.writeFile(file, data, err => {
-      test.error(err);
-
-      storage.compress(new common.Uint64(5), 'GZIP', (err, compressed) => {
-        test.error(err);
-        test.strictSame(compressed, false);
-
-        fs.readFile(file, 'utf8', (err, d) => {
-          test.error(err);
-          test.strictSame(d, data);
-          test.end();
-        });
-      });
-    });
-  });
+  await fs.mkdir(path.join(testDir, pathPart));
+  await fs.writeFile(file, data);
+  await test.resolves(storage.compress(id, 'GZIP'), false);
+  await test.resolves(fs.readFile(file, 'utf8'), data);
 });
 
-fsTest.test('Compress big file using zip', (test, { storage }) => {
+fsTest.test('Compress big file using zip', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
   const data = 'data6'.repeat(1000);
-  const file = utils.getFilepath(testDir, '0006', '0000');
 
-  fs.mkdir(path.join(testDir, '0006'), err => {
-    test.error(err);
+  await fs.mkdir(path.join(testDir, pathPart));
+  await fs.writeFile(file, data);
+  await test.resolves(storage.compress(id, 'ZIP'), true);
 
-    fs.writeFile(file, data, err => {
-      test.error(err);
+  const d = await fs.readFile(file, 'utf8');
+  test.strictNotSame(d, data);
 
-      storage.compress(new common.Uint64(6), 'ZIP', (err, compressed) => {
-        test.error(err);
-        test.strictSame(compressed, true);
-        test.strictSame(fs.statSync(file).size < 5000, true);
-
-        fs.readFile(file, 'utf8', (err, d) => {
-          test.error(err);
-          test.strictNotSame(d, data);
-          test.end();
-        });
-      });
-    });
-  });
+  const { size } = await fs.stat(file);
+  test.assert(size < 5000);
 });
 
-fsTest.test('Compress big file using gzip', (test, { storage }) => {
+fsTest.test('Compress big file using gzip', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
   const data = 'data7'.repeat(1000);
-  const file = utils.getFilepath(testDir, '0007', '0000');
 
-  fs.mkdir(path.join(testDir, '0007'), err => {
-    test.error(err);
+  await fs.mkdir(path.join(testDir, pathPart));
+  await fs.writeFile(file, data);
+  await test.resolves(storage.compress(id, 'GZIP'), true);
 
-    fs.writeFile(file, data, err => {
-      test.error(err);
+  const d = await fs.readFile(file, 'utf8');
+  test.strictNotSame(d, data);
 
-      storage.compress(new common.Uint64(7), 'GZIP', (err, compressed) => {
-        test.error(err);
-        test.strictSame(compressed, true);
-        test.strictSame(fs.statSync(file).size < 5000, true);
-
-        fs.readFile(file, 'utf8', (err, d) => {
-          test.error(err);
-          test.strictNotSame(d, data);
-          test.end();
-        });
-      });
-    });
-  });
+  const { size } = await fs.stat(file);
+  test.assert(size < 5000);
 });
 
-fsTest.test('Write and read small file', (test, { storage }) => {
-  const id = new common.Uint64(8);
+fsTest.test('Write and read small file', async (test, { storage, id }) => {
+  const opts = { checksum: 'CRC32', dedupHash: 'SHA256' };
   const data = 'data8';
-  const cs = '2e169402';
-  const dh = 'b5cc74ab5bb5a5f1acc7407be3e4cbce8611c5ed07354ab9e510b74ee0b273cb';
-  const dataSize = 5;
+  const dataStats = {
+    checksum: '2e169402',
+    dedupHash:
+      'b5cc74ab5bb5a5f1acc7407be3e4cbce8611c5ed07354ab9e510b74ee0b273cb',
+    size: 5,
+  };
 
-  storage.write(
-    id,
-    data,
-    { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, { checksum, dedupHash, size }) => {
-      test.error(err);
-      test.strictSame(checksum, cs);
-      test.strictSame(dedupHash, dh);
-      test.strictSame(size, dataSize);
-
-      storage.read(id, { encoding: 'utf8' }, (err, d) => {
-        test.error(err);
-        test.strictSame(d, data);
-        test.end();
-      });
-    }
-  );
+  await test.resolves(storage.write(id, data, opts), dataStats);
+  await test.resolves(storage.read(id, { encoding: 'utf8' }), data);
 });
 
-fsTest.test('Write, compress and read small file', (test, { storage }) => {
-  const id = new common.Uint64(9);
-  const data = 'data9';
-  const cs = '5911a494';
-  const dh = 'bbe0aa41024faeac81813a0194a95637d54cc65c025e0efd857ce0afcd51573f';
-  const dataSize = 5;
+fsTest.test(
+  'Write, compress, read small file',
+  async (test, { storage, id }) => {
+    const opts = { checksum: 'CRC32', dedupHash: 'SHA256' };
+    const data = 'data9';
+    const dataStats = {
+      checksum: '5911a494',
+      dedupHash:
+        'bbe0aa41024faeac81813a0194a95637d54cc65c025e0efd857ce0afcd51573f',
+      size: 5,
+    };
 
-  storage.write(
-    id,
-    data,
-    { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, { checksum, dedupHash, size }) => {
-      test.error(err);
-      test.strictSame(checksum, cs);
-      test.strictSame(dedupHash, dh);
-      test.strictSame(size, dataSize);
+    await test.resolves(storage.write(id, data, opts), dataStats);
+    await test.resolves(storage.compress(id, 'ZIP'), false);
+    await test.resolves(storage.read(id, { encoding: 'utf8' }), data);
+  }
+);
 
-      storage.compress(id, 'ZIP', (err, compressed) => {
-        test.error(err);
-        test.strictSame(compressed, false);
-
-        storage.read(id, { encoding: 'utf8' }, (err, d) => {
-          test.error(err);
-          test.strictSame(d, data);
-          test.end();
-        });
-      });
-    }
-  );
-});
-
-fsTest.test('Write and read big file', (test, { storage }) => {
-  const id = new common.Uint64(10);
+fsTest.test('Write and read big file', async (test, { storage, id }) => {
+  const opts = { checksum: 'CRC32', dedupHash: 'SHA256' };
   const data = 'data10'.repeat(1000);
-  const cs = '828aaf45';
-  const dh = '7a8553c5934fd3b4a068a3d4c5bafc189e1fe8e0f7f46cbcc0fc1199249a39a2';
-  const dataSize = 6000;
+  const dataStats = {
+    checksum: '828aaf45',
+    dedupHash:
+      '7a8553c5934fd3b4a068a3d4c5bafc189e1fe8e0f7f46cbcc0fc1199249a39a2',
+    size: 6000,
+  };
 
-  storage.write(
-    id,
-    data,
-    { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, { checksum, dedupHash, size }) => {
-      test.error(err);
-      test.strictSame(checksum, cs);
-      test.strictSame(dedupHash, dh);
-      test.strictSame(size, dataSize);
-
-      storage.read(id, { encoding: 'utf8' }, (err, d) => {
-        test.error(err);
-        test.strictSame(d, data);
-        test.end();
-      });
-    }
-  );
+  await test.resolves(storage.write(id, data, opts), dataStats);
+  await test.resolves(storage.read(id, { encoding: 'utf8' }), data);
 });
 
-fsTest.test('Write, compress and read big file', (test, { storage }) => {
-  const id = new common.Uint64(11);
-  const data = 'data11'.repeat(1000);
-  const cs = '5928f9a';
-  const dh = 'f1cf91dea01f77fd860645de51462794cfbbae0a14d81350b21934e58a69941d';
-  const dataSize = 6000;
+fsTest.test(
+  'Write, compress and read big file',
+  async (test, { storage, id }) => {
+    const opts = { checksum: 'CRC32', dedupHash: 'SHA256' };
+    const data = 'data11'.repeat(1000);
+    const dataStats = {
+      checksum: '5928f9a',
+      dedupHash:
+        'f1cf91dea01f77fd860645de51462794cfbbae0a14d81350b21934e58a69941d',
+      size: 6000,
+    };
 
-  storage.write(
-    id,
-    data,
-    { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, { checksum, dedupHash, size }) => {
-      test.error(err);
-      test.strictSame(checksum, cs);
-      test.strictSame(dedupHash, dh);
-      test.strictSame(size, dataSize);
+    await test.resolves(storage.write(id, data, opts), dataStats);
+    await test.resolves(storage.compress(id, 'ZIP'), true);
+    await test.resolves(
+      storage.read(id, { encoding: 'utf8', compression: 'ZIP' }),
+      data
+    );
+  }
+);
 
-      storage.compress(id, 'ZIP', (err, compressed) => {
-        test.error(err);
-        test.strictSame(compressed, true);
+fsTest.test(
+  'Write and read small unicode file',
+  async (test, { storage, id }) => {
+    const opts = { checksum: 'CRC32', dedupHash: 'SHA256' };
+    const data = '白い猫でも黒い猫でも鼠を取る猫はいい猫だ';
+    const dataStats = {
+      checksum: '289722d',
+      dedupHash:
+        'fab270bfcdc81e464611cd112e95c6b9590ba55483fbfe2dda98d67ddc741ab3',
+      size: 60,
+    };
 
-        storage.read(id, { encoding: 'utf8', compression: 'ZIP' }, (err, d) => {
-          test.error(err);
-          test.strictSame(d, data);
-          test.end();
-        });
-      });
-    }
-  );
-});
+    await test.resolves(storage.write(id, data, opts), dataStats);
+    await test.resolves(storage.read(id, { encoding: 'utf8' }), data);
+  }
+);
 
-fsTest.test('Write and read small file', (test, { storage }) => {
-  const id = new common.Uint64(12);
-  const data = '白い猫でも黒い猫でも鼠を取る猫はいい猫だ';
-  const cs = '289722d';
-  const dh = 'fab270bfcdc81e464611cd112e95c6b9590ba55483fbfe2dda98d67ddc741ab3';
-  const dataSize = 60;
-
-  storage.write(
-    id,
-    data,
-    { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, { checksum, dedupHash, size }) => {
-      test.error(err);
-      test.strictSame(checksum, cs);
-      test.strictSame(dedupHash, dh);
-      test.strictSame(size, dataSize);
-
-      storage.read(id, { encoding: 'utf8' }, (err, d) => {
-        test.error(err);
-        test.strictSame(d, data);
-        test.end();
-      });
-    }
-  );
-});
-
-fsTest.test('Get file stats', (test, { storage }) => {
+fsTest.test('Get file stats', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
   const data = 'data13';
-  const file = utils.getFilepath(testDir, '000d', '0000');
 
-  fs.mkdir(path.join(testDir, '000d'), err => {
-    test.error(err);
+  await fs.mkdir(path.join(testDir, pathPart));
+  await fs.writeFile(file, data);
 
-    fs.writeFile(file, data, err => {
-      test.error(err);
-
-      fs.stat(file, (err, fstats) => {
-        test.error(err);
-
-        storage.stat(new common.Uint64(13), (err, stats) => {
-          test.error(err);
-          test.strictSame(stats, fstats);
-          test.end();
-        });
-      });
-    });
-  });
+  const fstats = await fs.stat(file);
+  await test.resolves(storage.stat(id), fstats);
 });
 
-fsTest.test('Update file', (test, { storage }) => {
+fsTest.test('Update file', async (test, { storage, id }) => {
+  const pathPart = id.toString(16).padStart(4, '0');
+  const file = utils.getFilepath(testDir, pathPart, '0000');
+  const opts = { checksum: 'CRC32', dedupHash: 'SHA256' };
   const data1 = 'data15';
-  const cs1 = 'bb53e75f';
-  const dh1 =
-    '87fef323635f22fc88999957a585c3cf3f8383029c8501e52928a14028c0af2c';
-  const dataSize1 = 6;
-
   const data2 = 'another data';
-  const cs2 = '963fe1ef';
-  const dh2 =
-    'f3cfa0c4064755101ffbcdc8a8d1b9dccc46d45b3a82f800a6eaab42e65f14c9';
-  const dataSize2 = 12;
+  const dataStats1 = {
+    checksum: 'bb53e75f',
+    dedupHash:
+      '87fef323635f22fc88999957a585c3cf3f8383029c8501e52928a14028c0af2c',
+    size: 6,
+  };
+  const dataStats2 = {
+    checksum: '963fe1ef',
+    dedupHash:
+      'f3cfa0c4064755101ffbcdc8a8d1b9dccc46d45b3a82f800a6eaab42e65f14c9',
+    size: 12,
+    originalSize: 6,
+  };
 
-  const id = new common.Uint64(15);
-
-  storage.write(
-    id,
-    data1,
-    { checksum: 'CRC32', dedupHash: 'SHA256' },
-    (err, { checksum, dedupHash, size }) => {
-      test.error(err);
-      test.strictSame(checksum, cs1);
-      test.strictSame(dedupHash, dh1);
-      test.strictSame(size, dataSize1);
-
-      storage.update(
-        id,
-        data2,
-        { checksum: 'CRC32', dedupHash: 'SHA256' },
-        (err, { checksum, dedupHash, size, originalSize }) => {
-          test.error(err);
-          test.strictSame(checksum, cs2);
-          test.strictSame(dedupHash, dh2);
-          test.strictSame(size, dataSize2);
-          test.strictSame(originalSize, dataSize1);
-
-          fs.readFile(utils.getFilepath(testDir, '000f', '0000'), (err, d) => {
-            test.error(err);
-            test.strictSame(d.toString(), data2);
-            test.end();
-          });
-        }
-      );
-    }
-  );
+  await test.resolves(storage.write(id, data1, opts), dataStats1);
+  await test.resolves(storage.update(id, data2, opts), dataStats2);
+  await test.resolves(fs.readFile(file, 'utf8'), data2);
 });

--- a/test/filestorage.js
+++ b/test/filestorage.js
@@ -23,7 +23,7 @@ fsTest.beforeEach(async () => {
   return { storage, id };
 });
 
-fsTest.afterEach(() => utils.rmRecursive(testDir));
+fsTest.afterEach(() => common.rmRecursivePromise(testDir));
 
 fsTest.test('Create root directory on create', () => fs.access(testDir));
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const fs = require('../lib/fs');
-const path = require('path');
 const utils = require('../lib/utils');
+const path = require('path');
+const common = require('@metarhia/common');
 const metatests = require('metatests');
 
 const testDir = path.join(__dirname, 'utils-test-root');
@@ -54,23 +55,24 @@ metatests.case('', utils, {
     ['data4', 'CRC32', '27a0d829'],
     ['data5', 'CRC32', '50a7e8bf'],
   ],
-});
-
-metatests.testSync('getDataStats', test => {
-  const data = 'data6';
-  const cs = '9c67b4b76a18503009f542ef7c93dc7ac94aebbc6141515bea4e63e3068373a6';
-  const dh = 'c9aeb905';
-  const dataSize = 5;
-
-  const stats = utils.getDataStats(data, 'SHA256', 'CRC32');
-  test.strictSame(stats.checksum, cs);
-  test.strictSame(stats.dedupHash, dh);
-  test.strictSame(stats.size, dataSize);
+  getDataStats: [
+    [
+      'data6',
+      'SHA256',
+      'CRC32',
+      {
+        checksum:
+          '9c67b4b76a18503009f542ef7c93dc7ac94aebbc6141515bea4e63e3068373a6',
+        dedupHash: 'c9aeb905',
+        size: 5,
+      },
+    ],
+  ],
 });
 
 metatests.test('Compress and uncompress file', async test => {
   const dir = path.join(testDir, 'some', 'path', 'to', 'nested', 'dir');
-  await utils.mkdirRecursive(dir);
+  await utils.mkdirpPromise(dir);
   await fs.access(testDir);
 
   const file = path.join(testDir, 'file');
@@ -84,5 +86,5 @@ metatests.test('Compress and uncompress file', async test => {
   test.assert(size < data.length);
 
   await test.resolves(utils.uncompress(file, opts), data);
-  await utils.rmRecursive(testDir);
+  await common.rmRecursivePromise(testDir);
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -70,12 +70,13 @@ metatests.case('', utils, {
   ],
 });
 
-metatests.test('Compress and uncompress file', async test => {
-  const dir = path.join(testDir, 'some', 'path', 'to', 'nested', 'dir');
-  await utils.mkdirpPromise(dir);
-  await fs.access(testDir);
+const compressTest = metatests.test();
+compressTest.endAfterSubtests();
+compressTest.beforeEach(() => utils.mkdirpPromise(testDir));
+compressTest.afterEach(() => common.rmRecursivePromise(testDir));
 
-  const file = path.join(testDir, 'file');
+compressTest.test('Compress and uncompress ZIP file', async test => {
+  const file = path.join(testDir, 'file.zip');
   const data = 'data'.repeat(1000);
   const opts = { compression: 'ZIP', encoding: 'utf8' };
 
@@ -86,5 +87,18 @@ metatests.test('Compress and uncompress file', async test => {
   test.assert(size < data.length);
 
   await test.resolves(utils.uncompress(file, opts), data);
-  await common.rmRecursivePromise(testDir);
+});
+
+compressTest.test('Compress and uncompress GZIP file', async test => {
+  const file = path.join(testDir, 'file.gzip');
+  const data = 'data'.repeat(1000);
+  const opts = { compression: 'GZIP', encoding: 'utf8' };
+
+  await fs.writeFile(file, data);
+  await utils.compress(file, 1024, 'GZIP');
+
+  const { size } = await fs.stat(file);
+  test.assert(size < data.length);
+
+  await test.resolves(utils.uncompress(file, opts), data);
 });


### PR DESCRIPTION
[@metarhia/globalstorage](https://github.com/metarhia/globalstorage) changed its API from callbacks to promises in https://github.com/metarhia/globalstorage/pull/416. In order to also [update `FsProvider`](https://github.com/metarhia/globalstorage/pull/310), [@metarhia/filestorage](https://github.com/metarhia/filestorage)  should also be updated.